### PR TITLE
.lgtm.yml: remove GCC 6 override

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -5,13 +5,6 @@ path_classifiers:
   test: "/tests/*.cpp"
 extraction:
   cpp:
-    prepare:
-      packages: "g++-6"
-    after_prepare:
-    - "mkdir -p $LGTM_WORKSPACE/latest-gcc-symlinks"
-    - "ln -s /usr/bin/g++-6 $LGTM_WORKSPACE/latest-gcc-symlinks/g++"
-    - "ln -s /usr/bin/gcc-6 $LGTM_WORKSPACE/latest-gcc-symlinks/gcc"
-    - "export PATH=$LGTM_WORKSPACE/latest-gcc-symlinks:$PATH"
     index:
       build_command:
       - "export COMPILER=g++"


### PR DESCRIPTION
This override of the compiler to always use GCC 6 seems to have been copied from [an example in the LGTM documentation](https://help.semmle.com/lgtm-enterprise/archive/1.22/user/help/lgtm.yml-configuration-file.html#example-lgtm.yml-file) that was not intended to be used literally. We'll update that example before our next release.

I've tested that the build still works at https://lgtm.com/logs/f079baac7051b476f0ac2404b926592488f81df8/lang:cpp.